### PR TITLE
Add current tick route + display

### DIFF
--- a/backend-go/internal/obc/client.go
+++ b/backend-go/internal/obc/client.go
@@ -45,3 +45,31 @@ func (c *Client) GetStatus() ([]byte, int) {
 	// Return the body and the status code from the OBC's response
 	return body, resp.StatusCode
 }
+
+
+// GetTick retrieves the current tick from the OBC's /tick endpoint.
+// It returns the response body and the HTTP status code.
+func (c *Client) GetTick() ([]byte, int) {
+	// Construct the full URL for the request
+	requestURL := fmt.Sprintf("%s/tick", c.urlBase)
+
+	// Perform the GET request
+    resp, err := c.httpClient.Get(requestURL)
+	if err != nil {
+		// If there's a network error, we can't connect.
+		log.Printf("FATAL: OBC client request failed with network error: %v", err)
+
+        return nil, http.StatusBadGateway
+	}
+	defer resp.Body.Close()
+
+	// Read the response body from the OBC
+    body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// If we can't read the body, it's an internal server error.
+        return nil, http.StatusInternalServerError
+	}
+
+	// Return the body and the status code from the OBC's response
+    return body, resp.StatusCode
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -29,6 +29,7 @@ func (s *Server) setupRouter() {
 	api := router.Group("/api/v1")
 	{
 		api.GET("/obc/status", s.getOBCStatus())
+        api.GET("/obc/tick", s.getOBCTick())
 	}
 
 	s.router = router
@@ -56,6 +57,23 @@ func (s *Server) getOBCStatus() gin.HandlerFunc {
 
 		c.Data(http.StatusOK, "application/json", body)
 	}
+}
+
+// handler for /api/v1/obc/tick
+func (s *Server) getOBCTick() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        log.Println("Handler invoked: Proxying tick request to OBC.")
+
+        body, statusCode := s.obcClient.GetTick()
+
+        if statusCode != http.StatusOK {
+            log.Printf("Error from OBC client tick. Status: %d", statusCode)
+            c.JSON(statusCode, gin.H{"error": "Failed to get tick from OBC."})
+            return
+        }
+
+        c.Data(http.StatusOK, "text/plain; charset=utf-8", body)
+    }
 }
 
 func CORSMiddleware() gin.HandlerFunc {


### PR DESCRIPTION
Closes #7 

I added a route for fetching the current tick and displaying it on the same page as the obc status (as I think it makes sense and reduces the need to create a separate tab; though it is kind of redundant that the obc status itself already displays the current tick information).

To test this, also use the `feat/current_tick` branch on the obc.